### PR TITLE
chore(build workflow): deployment_check step added

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,8 +86,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, tag]
     steps:
+      - name: Check if deployment PAT is set
+        id: deployment_check
+        run: |
+          if [ -z "${{ secrets.DEPLOYMENT_PAT }}" ]; then
+            echo "DEPLOYMENT_PAT is not set. Skipping deployment."
+            echo "deployment_enabled=false" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "deployment_enabled=true" >> $GITHUB_OUTPUT
+            echo "deployment_enabled=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Update deployment
         uses: actions/github-script@v7
+        if: steps.deployment_check.outputs.deployment_enabled == 'true'
         with:
           github-token: ${{ secrets.DEPLOYMENT_PAT }}
           script: |


### PR DESCRIPTION
The changes prevents the workflow from failing when no PAT is provided.